### PR TITLE
[FEATURE] Mark heroes who will stay idle and not quest

### DIFF
--- a/Bot/DFKBot.cs
+++ b/Bot/DFKBot.cs
@@ -190,18 +190,18 @@ public class DFKBot
         return new();
     }
 
-    public int GetMinStaminaBotHero(DFKBotHero h)
-    {
-        if (h.Quest is null && h.SuggestedQuest is null)
-        {
-            return 999;
-        }
-        int stam = ChainQuestSettings.FirstOrDefault(qs => qs.QuestId == (h.Quest?.Id ?? h.SuggestedQuest.Id))?.MinStamina ?? Settings.MinStamina;
+	public int GetMinStaminaBotHero(DFKBotHero h)
+	{
+		if (h.Quest is null && (Settings.EnableNotQuestingWithoutPreferredQuest || h.SuggestedQuest is null))
+		{
+			return 999;
+		}
+		int stam = ChainQuestSettings.FirstOrDefault(qs => qs.QuestId == (h.Quest?.Id ?? h.SuggestedQuest.Id))?.MinStamina ?? Settings.MinStamina;
 
-        return stam;
-    }
+		return stam;
+	}
 
-    public async Task Update()
+	public async Task Update()
     {
         ChainQuestSettings = Settings.ChainQuestEnabled.Find(cqe => cqe.Chain.Name == Account.Chain.Name).QuestEnabled;
         await UpdateCurrentBlock();

--- a/Bot/DFKBotSettings.cs
+++ b/Bot/DFKBotSettings.cs
@@ -2,226 +2,227 @@
 
 namespace PirateQuester.Bot
 {
-    public class DFKBotSettings
-    {
-        public DFKBotSettings()
-        {
-            List<int> eagerQuests = new()
-            {
-                0,1,2,3,4,5,6,7,10,11
-            };
-            ChainQuestEnabled = new()
-            {
-                new()
-                {
-                    Chain = Constants.ChainsList[0],
-                    QuestEnabled = Enumerable.Range(0, 40).Select(i =>
-                    new QuestEnabled()
-                    {
-                        Enabled = true,
-                        QuestId = i,
-                        QuestEagerly = eagerQuests.Contains(i)
-                    }).ToList()
-                },
-                new ()
-                {
-                    Chain = Constants.ChainsList[1],
-                    QuestEnabled = Enumerable.Range(0, 36).Select(i =>
-                    new QuestEnabled()
-                    {
-                        Enabled = true,
-                        QuestId = i,
-                        QuestEagerly = eagerQuests.Contains(i)
-                    }).ToList()
-                }
-            };
-        }
-        public int ClearLogsInterval { get; set; } = 86400;
-        public bool DownloadClearedLogs { get; set; } = false;
-        public int CancelTxnDelay { get; set; } = 60000;
-        public int UpdateInterval { get; set; } = 180;
-        public int MinStamina { get; set; } = 20;
-        public decimal MaxGasFeeGwei { get; set; } = 200;
-        public decimal MaxGasFeeGweiKlaytn { get; set; } = 40;
-        public decimal MaxPriorityFeeGwei { get; set; } = 0;
-        public decimal MaxPriorityFeeGweiKlaytn { get; set; } = 0;
-        public decimal WarnFloorPercentage { get; set; } = 90;
-        public bool LevelUp { get; set; } = true;
-        public bool UseStaminaPotions { get; set; } = true;
-        public bool ForceStampotOnFullXP { get; set; } = false;
-        public bool QuestHeroes { get; set; } = true;
-        public bool CancelUnpricedHeroSales { get; set; } = false;
-        public bool SellHeroes { get; set; } = true;
-        public List<ChainQuestEnabled> ChainQuestEnabled { get; set; } = new();
-        public List<DFKStatAmount> MinTrainingStats { get; set; } = new()
-        {
-            { new(0, 30) },
-            { new(1, 30) },
-            { new(2, 30) },
-            { new(3, 30) },
-            { new(4, 30) },
-            { new(5, 30) },
-            { new(6, 30) },
-            { new(7, 30) }
-        };
+	public class DFKBotSettings
+	{
+		public DFKBotSettings()
+		{
+			List<int> eagerQuests = new()
+			{
+				0,1,2,3,4,5,6,7,10,11
+			};
+			ChainQuestEnabled = new()
+			{
+				new()
+				{
+					Chain = Constants.ChainsList[0],
+					QuestEnabled = Enumerable.Range(0, 40).Select(i =>
+					new QuestEnabled()
+					{
+						Enabled = true,
+						QuestId = i,
+						QuestEagerly = eagerQuests.Contains(i)
+					}).ToList()
+				},
+				new ()
+				{
+					Chain = Constants.ChainsList[1],
+					QuestEnabled = Enumerable.Range(0, 36).Select(i =>
+					new QuestEnabled()
+					{
+						Enabled = true,
+						QuestId = i,
+						QuestEagerly = eagerQuests.Contains(i)
+					}).ToList()
+				}
+			};
+		}
+		public int ClearLogsInterval { get; set; } = 86400;
+		public bool DownloadClearedLogs { get; set; } = false;
+		public int CancelTxnDelay { get; set; } = 60000;
+		public int UpdateInterval { get; set; } = 180;
+		public int MinStamina { get; set; } = 20;
+		public decimal MaxGasFeeGwei { get; set; } = 200;
+		public decimal MaxGasFeeGweiKlaytn { get; set; } = 40;
+		public decimal MaxPriorityFeeGwei { get; set; } = 0;
+		public decimal MaxPriorityFeeGweiKlaytn { get; set; } = 0;
+		public decimal WarnFloorPercentage { get; set; } = 90;
+		public bool LevelUp { get; set; } = true;
+		public bool UseStaminaPotions { get; set; } = true;
+		public bool ForceStampotOnFullXP { get; set; } = false;
+		public bool EnableNotQuestingWithoutPreferredQuest { get; set; } = false;
+		public bool QuestHeroes { get; set; } = true;
+		public bool CancelUnpricedHeroSales { get; set; } = false;
+		public bool SellHeroes { get; set; } = true;
+		public List<ChainQuestEnabled> ChainQuestEnabled { get; set; } = new();
+		public List<DFKStatAmount> MinTrainingStats { get; set; } = new()
+		{
+			{ new(0, 30) },
+			{ new(1, 30) },
+			{ new(2, 30) },
+			{ new(3, 30) },
+			{ new(4, 30) },
+			{ new(5, 30) },
+			{ new(6, 30) },
+			{ new(7, 30) }
+		};
 
-        public List<HeroQuestSetting> HeroQuestSettings { get; set; } = new();
-        public List<LevelUpSetting> LevelUpSettings { get; set; } = new()
-        {
-            new()
-            {
-                HeroClass = "warrior",
-                MainAttribute = Constants.DFKStats[0],
-                SecondaryAttribute = Constants.DFKStats[1],
-                TertiaryAttribute = Constants.DFKStats[3],
-            },
-            new()
-            {
-                HeroClass = "knight",
-                MainAttribute = Constants.DFKStats[3],
-                SecondaryAttribute = Constants.DFKStats[4],
-                TertiaryAttribute = Constants.DFKStats[0],
-            },
-            new()
-            {
-                HeroClass = "thief",
-                MainAttribute = Constants.DFKStats[2],
-                SecondaryAttribute = Constants.DFKStats[7],
-                TertiaryAttribute = Constants.DFKStats[1],
-            },
-            new()
-            {
-                HeroClass = "archer",
-                MainAttribute = Constants.DFKStats[1],
-                SecondaryAttribute = Constants.DFKStats[4],
-                TertiaryAttribute = Constants.DFKStats[0],
-            },
-            new()
-            {
-                HeroClass = "pirate",
-                MainAttribute = Constants.DFKStats[0],
-                SecondaryAttribute = Constants.DFKStats[1],
-                TertiaryAttribute = Constants.DFKStats[3],
-            },
-            new()
-            {
-                HeroClass = "monk",
-                MainAttribute = Constants.DFKStats[0],
-                SecondaryAttribute = Constants.DFKStats[2],
-                TertiaryAttribute = Constants.DFKStats[3],
-            },
-            new()
-            {
-                HeroClass = "priest",
-                MainAttribute = Constants.DFKStats[6],
-                SecondaryAttribute = Constants.DFKStats[5],
-                TertiaryAttribute = Constants.DFKStats[4],
-            },
-            new()
-            {
-                HeroClass = "wizard",
-                MainAttribute = Constants.DFKStats[5],
-                SecondaryAttribute = Constants.DFKStats[6],
-                TertiaryAttribute = Constants.DFKStats[3],
-            },
-            new()
-            {
-                HeroClass = "seer",
-                MainAttribute = Constants.DFKStats[6],
-                SecondaryAttribute = Constants.DFKStats[5],
-                TertiaryAttribute = Constants.DFKStats[2],
-            },
-            new()
-            {
-                HeroClass = "berserker",
-                MainAttribute = Constants.DFKStats[0],
-                SecondaryAttribute = Constants.DFKStats[3],
-                TertiaryAttribute = Constants.DFKStats[1],
-            },
-            new()
-            {
-                HeroClass = "legionnaire",
-                MainAttribute = Constants.DFKStats[4],
-                SecondaryAttribute = Constants.DFKStats[0],
-                TertiaryAttribute = Constants.DFKStats[3],
-            },
-            new()
-            {
-                HeroClass = "scholar",
-                MainAttribute = Constants.DFKStats[5],
-                SecondaryAttribute = Constants.DFKStats[6],
-                TertiaryAttribute = Constants.DFKStats[3],
-            },
-            new()
-            {
-                HeroClass = "paladin",
-                MainAttribute = Constants.DFKStats[0],
-                SecondaryAttribute = Constants.DFKStats[3],
-                TertiaryAttribute = Constants.DFKStats[4],
-            },
-            new()
-            {
-                HeroClass = "darkknight",
-                MainAttribute = Constants.DFKStats[0],
-                SecondaryAttribute = Constants.DFKStats[3],
-                TertiaryAttribute = Constants.DFKStats[5],
-            },
-            new()
-            {
-                HeroClass = "ninja",
-                MainAttribute = Constants.DFKStats[2],
-                SecondaryAttribute = Constants.DFKStats[1],
-                TertiaryAttribute = Constants.DFKStats[7],
-            },
-            new()
-            {
-                HeroClass = "summoner",
-                MainAttribute = Constants.DFKStats[5],
-                SecondaryAttribute = Constants.DFKStats[6],
-                TertiaryAttribute = Constants.DFKStats[3],
-            },
-            new()
-            {
-                HeroClass = "shapeshifter",
-                MainAttribute = Constants.DFKStats[2],
-                SecondaryAttribute = Constants.DFKStats[1],
-                TertiaryAttribute = Constants.DFKStats[3],
-            },
-            new()
-            {
-                HeroClass = "bard",
-                MainAttribute = Constants.DFKStats[1],
-                SecondaryAttribute = Constants.DFKStats[2],
-                TertiaryAttribute = Constants.DFKStats[7],
-            },
-            new()
-            {
-                HeroClass = "dragoon",
-                MainAttribute = Constants.DFKStats[0],
-                SecondaryAttribute = Constants.DFKStats[1],
-                TertiaryAttribute = Constants.DFKStats[2],
-            },
-            new()
-            {
-                HeroClass = "sage",
-                MainAttribute = Constants.DFKStats[5],
-                SecondaryAttribute = Constants.DFKStats[6],
-                TertiaryAttribute = Constants.DFKStats[2],
-            },
-            new()
-            {
-                HeroClass = "spellbow",
-                MainAttribute = Constants.DFKStats[1],
-                SecondaryAttribute = Constants.DFKStats[5],
-                TertiaryAttribute = Constants.DFKStats[7],
-            },
-            new()
-            {
-                HeroClass = "dreadknight",
-                MainAttribute = Constants.DFKStats[0],
-                SecondaryAttribute = Constants.DFKStats[1],
-                TertiaryAttribute = Constants.DFKStats[4],
-            },
-        };
-    }
+		public List<HeroQuestSetting> HeroQuestSettings { get; set; } = new();
+		public List<LevelUpSetting> LevelUpSettings { get; set; } = new()
+		{
+			new()
+			{
+				HeroClass = "warrior",
+				MainAttribute = Constants.DFKStats[0],
+				SecondaryAttribute = Constants.DFKStats[1],
+				TertiaryAttribute = Constants.DFKStats[3],
+			},
+			new()
+			{
+				HeroClass = "knight",
+				MainAttribute = Constants.DFKStats[3],
+				SecondaryAttribute = Constants.DFKStats[4],
+				TertiaryAttribute = Constants.DFKStats[0],
+			},
+			new()
+			{
+				HeroClass = "thief",
+				MainAttribute = Constants.DFKStats[2],
+				SecondaryAttribute = Constants.DFKStats[7],
+				TertiaryAttribute = Constants.DFKStats[1],
+			},
+			new()
+			{
+				HeroClass = "archer",
+				MainAttribute = Constants.DFKStats[1],
+				SecondaryAttribute = Constants.DFKStats[4],
+				TertiaryAttribute = Constants.DFKStats[0],
+			},
+			new()
+			{
+				HeroClass = "pirate",
+				MainAttribute = Constants.DFKStats[0],
+				SecondaryAttribute = Constants.DFKStats[1],
+				TertiaryAttribute = Constants.DFKStats[3],
+			},
+			new()
+			{
+				HeroClass = "monk",
+				MainAttribute = Constants.DFKStats[0],
+				SecondaryAttribute = Constants.DFKStats[2],
+				TertiaryAttribute = Constants.DFKStats[3],
+			},
+			new()
+			{
+				HeroClass = "priest",
+				MainAttribute = Constants.DFKStats[6],
+				SecondaryAttribute = Constants.DFKStats[5],
+				TertiaryAttribute = Constants.DFKStats[4],
+			},
+			new()
+			{
+				HeroClass = "wizard",
+				MainAttribute = Constants.DFKStats[5],
+				SecondaryAttribute = Constants.DFKStats[6],
+				TertiaryAttribute = Constants.DFKStats[3],
+			},
+			new()
+			{
+				HeroClass = "seer",
+				MainAttribute = Constants.DFKStats[6],
+				SecondaryAttribute = Constants.DFKStats[5],
+				TertiaryAttribute = Constants.DFKStats[2],
+			},
+			new()
+			{
+				HeroClass = "berserker",
+				MainAttribute = Constants.DFKStats[0],
+				SecondaryAttribute = Constants.DFKStats[3],
+				TertiaryAttribute = Constants.DFKStats[1],
+			},
+			new()
+			{
+				HeroClass = "legionnaire",
+				MainAttribute = Constants.DFKStats[4],
+				SecondaryAttribute = Constants.DFKStats[0],
+				TertiaryAttribute = Constants.DFKStats[3],
+			},
+			new()
+			{
+				HeroClass = "scholar",
+				MainAttribute = Constants.DFKStats[5],
+				SecondaryAttribute = Constants.DFKStats[6],
+				TertiaryAttribute = Constants.DFKStats[3],
+			},
+			new()
+			{
+				HeroClass = "paladin",
+				MainAttribute = Constants.DFKStats[0],
+				SecondaryAttribute = Constants.DFKStats[3],
+				TertiaryAttribute = Constants.DFKStats[4],
+			},
+			new()
+			{
+				HeroClass = "darkknight",
+				MainAttribute = Constants.DFKStats[0],
+				SecondaryAttribute = Constants.DFKStats[3],
+				TertiaryAttribute = Constants.DFKStats[5],
+			},
+			new()
+			{
+				HeroClass = "ninja",
+				MainAttribute = Constants.DFKStats[2],
+				SecondaryAttribute = Constants.DFKStats[1],
+				TertiaryAttribute = Constants.DFKStats[7],
+			},
+			new()
+			{
+				HeroClass = "summoner",
+				MainAttribute = Constants.DFKStats[5],
+				SecondaryAttribute = Constants.DFKStats[6],
+				TertiaryAttribute = Constants.DFKStats[3],
+			},
+			new()
+			{
+				HeroClass = "shapeshifter",
+				MainAttribute = Constants.DFKStats[2],
+				SecondaryAttribute = Constants.DFKStats[1],
+				TertiaryAttribute = Constants.DFKStats[3],
+			},
+			new()
+			{
+				HeroClass = "bard",
+				MainAttribute = Constants.DFKStats[1],
+				SecondaryAttribute = Constants.DFKStats[2],
+				TertiaryAttribute = Constants.DFKStats[7],
+			},
+			new()
+			{
+				HeroClass = "dragoon",
+				MainAttribute = Constants.DFKStats[0],
+				SecondaryAttribute = Constants.DFKStats[1],
+				TertiaryAttribute = Constants.DFKStats[2],
+			},
+			new()
+			{
+				HeroClass = "sage",
+				MainAttribute = Constants.DFKStats[5],
+				SecondaryAttribute = Constants.DFKStats[6],
+				TertiaryAttribute = Constants.DFKStats[2],
+			},
+			new()
+			{
+				HeroClass = "spellbow",
+				MainAttribute = Constants.DFKStats[1],
+				SecondaryAttribute = Constants.DFKStats[5],
+				TertiaryAttribute = Constants.DFKStats[7],
+			},
+			new()
+			{
+				HeroClass = "dreadknight",
+				MainAttribute = Constants.DFKStats[0],
+				SecondaryAttribute = Constants.DFKStats[1],
+				TertiaryAttribute = Constants.DFKStats[4],
+			},
+		};
+	}
 }

--- a/Pages/Bot.razor
+++ b/Pages/Bot.razor
@@ -9,357 +9,367 @@
 
 
 <div class="container-fluid">
-	<BotTerminalNavigation />
-	<h4 class="text-center">Settings</h4>
-	<SfCard>
-		<CardContent>
-			<EditForm Model="@Bots.Settings">
-				<DataAnnotationsValidator />
-				<div class="my-1 text-center">
-					<SfButton CssClass="e-success mx-1" Disabled="Bots.CheckRunning()" OnClick="@Bots.RunBots">
-						Run Bots
-					</SfButton>
-					<SfButton CssClass="e-danger mx-1" Disabled="Bots.RunningBots.All(bot => bot.StopBot)" OnClick="@Bots.StopBots" >
-						Stop Bots
-					</SfButton>
-					<SfButton CssClass="e-primary mx-1" Disabled="Bots.RunningBots.All(bot => bot.StopBot)" OnClick="RefreshBots">
-						Clear Logs
-					</SfButton>
-					<SfButton CssClass="e-primary mx-1" HtmlAttributes="@(new(){{"type", "button"}})" OnClick="@Bots.SaveSettings">
-						Save Settings
-					</SfButton>
-				</div>
-				<div class="row">
-					<div class="col-md-6">
-						Download cleared logs
-						<SfCheckBox @bind-Checked=@Bots.Settings.DownloadClearedLogs />
-						<label for="UpdateInterval" >
-							Clear logs interval (Seconds) (0 to turn off)<br />
-						</label>
-						<SfNumericTextBox name="UpdateInterval"
-							TValue="int"
-							@bind-Value="@Bots.Settings.ClearLogsInterval"
-							OnChange="@((val) => {Bots.SaveSettings();})" />
-					</div>
-					<div class="col-md-6">
-						<label for="UpdateInterval" >
-							Update Frequency (Seconds)
-						</label>
-						<SfNumericTextBox name="UpdateInterval"
-							TValue="int"
-							@bind-Value="@Bots.Settings.UpdateInterval"
-							OnChange="@((val) => {Bots.SaveSettings();})" />
-					</div>
+    <BotTerminalNavigation />
+    <h4 class="text-center">Settings</h4>
+    <SfCard>
+        <CardContent>
+            <EditForm Model="@Bots.Settings">
+                <DataAnnotationsValidator />
+                <div class="my-1 text-center">
+                    <SfButton CssClass="e-success mx-1" Disabled="Bots.CheckRunning()" OnClick="@Bots.RunBots">
+                        Run Bots
+                    </SfButton>
+                    <SfButton CssClass="e-danger mx-1" Disabled="Bots.RunningBots.All(bot => bot.StopBot)" OnClick="@Bots.StopBots">
+                        Stop Bots
+                    </SfButton>
+                    <SfButton CssClass="e-primary mx-1" Disabled="Bots.RunningBots.All(bot => bot.StopBot)" OnClick="RefreshBots">
+                        Clear Logs
+                    </SfButton>
+                    <SfButton CssClass="e-primary mx-1" HtmlAttributes="@(new(){{"type", "button"}})" OnClick="@Bots.SaveSettings">
+                        Save Settings
+                    </SfButton>
+                </div>
+                <div class="row">
+                    <div class="col-md-6">
+                        Download cleared logs
+                        <SfCheckBox @bind-Checked=@Bots.Settings.DownloadClearedLogs />
+                        <label for="UpdateInterval">
+                            Clear logs interval (Seconds) (0 to turn off)<br />
+                        </label>
+                        <SfNumericTextBox name="UpdateInterval"
+                                          TValue="int"
+                        @bind-Value="@Bots.Settings.ClearLogsInterval"
+                                          OnChange="@((val) => {Bots.SaveSettings();})" />
+                    </div>
+                    <div class="col-md-6">
+                        <label for="UpdateInterval">
+                            Update Frequency (Seconds)
+                        </label>
+                        <SfNumericTextBox name="UpdateInterval"
+                                          TValue="int"
+                        @bind-Value="@Bots.Settings.UpdateInterval"
+                                          OnChange="@((val) => {Bots.SaveSettings();})" />
+                    </div>
 
-					<div class="col-md-6">
-						<label for="MinStamina" >
-							Min Stamina to Quest
-						</label>
-						<SfNumericTextBox name="MinStamina"
-							TValue="int"
-							@bind-Value="@Bots.Settings.MinStamina"
-							OnChange="@((val) => {Bots.SaveSettings();})" />
-					</div>
-					
-					<div class="col-md-6">
-						<label for="CancelTxnDelay" >
-							Cancel transaction delay. (Milliseconds)
-						</label>
-					
-						<SfNumericTextBox name="CancelTxnDelay"
-							TValue="int"
-							@bind-Value="@Bots.Settings.CancelTxnDelay"
-							OnChange="@((val) => {Bots.SaveSettings();})" />
-					</div>
-					
-					<div class="col-md-6 w100-tooltip">
-						<label for="MaxGasFee">
-							Max Gas Fee DFK
-						</label>
-						<SfNumericTextBox name="MaxGasFee"
-										  TValue="decimal"
-										  @bind-Value="@Bots.Settings.MaxGasFeeGwei"
-										  OnChange="@((val) => {Bots.SaveSettings();})" />
-						<SfTooltip ID="tooltip"
-							IsSticky="false"
-							CloseDelay="500"
-							Target="#target"
-							Content="@($"Be careful about setting Priority fee too high, it will quickly drain your gas. Recommended range is between 0 and 1. If your transactions are failing increase priority fees a bit and restart the bot.")">
-						<label for="MaxPriorityFee" id="target">
-							Max Priority Fee DFK
-						</label>
-						<SfNumericTextBox name="MaxPriorityFee"
-										  TValue="decimal"
-										  @bind-Value="@Bots.Settings.MaxPriorityFeeGwei"
-										  OnChange="@((val) => {Bots.SaveSettings();})" />
-						</SfTooltip>
-					</div>
-					<div class="col-md-6 w100-tooltip">
-						<label for="MaxGasFeeKlaytn">
-							Max Gas Fee Klaytn
-						</label>
-						<SfNumericTextBox name="MaxGasFeeKlaytn"
-										  TValue="decimal"
-										  @bind-Value="@Bots.Settings.MaxGasFeeGweiKlaytn"
-										  OnChange="@((val) => {Bots.SaveSettings();})" />
-						<SfTooltip ID="tooltip"
-							IsSticky="false"
-							CloseDelay="500"
-							Target="#target"
-							Content="@($"Be careful about setting Priority fee too high, it will quickly drain your gas. Recommended range is between 0 and 1. If your transactions are failing increase priority fees a bit and restart the bot.")">
-							<label for="MaxPriorityFeeKlaytn" id="target">
-								Max Priority Fee Klaytn
-							</label>
-							<SfNumericTextBox name="MaxPriorityFeeKlaytn"
-											  TValue="decimal"
-											  Min="0"
-											  Max="999"
-											  @bind-Value="@Bots.Settings.MaxPriorityFeeGweiKlaytn"
-											  OnChange="@((val) => {Bots.SaveSettings();})" />
-						</SfTooltip>
-					</div>
-					
-					<div class="col-md-3 text-center mb-1">
-						<label>
-							Enable Hero Selling
-							<SfCheckBox
-								@bind-Checked=@Bots.Settings.SellHeroes
-								/>
-						</label>
-					</div>
-					<div class="col-md-3 text-center mb-1">
-						<label>
-							Cancel Unpriced Hero Sales
-							<SfCheckBox @bind-Checked=@Bots.Settings.CancelUnpricedHeroSales />
-						</label>
-					</div>
-					<div class="col-md-3 text-center mb-1">
-						<label>
-							Enable Questing
-							<SfCheckBox @bind-Checked=@Bots.Settings.QuestHeroes />
-						</label>
-					</div>
-					<div class="col-md-3 text-center mb-1">
-						<label>
-							Use Stampots
-							<SfCheckBox @bind-Checked=@Bots.Settings.UseStaminaPotions />
-						</label>
-					</div>
-					<div class="col-md-3 text-center mb-1">
-						<label>
-							Force Stampots On Full XP
-							<SfCheckBox @bind-Checked=@Bots.Settings.ForceStampotOnFullXP />
-						</label>
-					</div>
-					@if(Bots.Settings.QuestHeroes)
-					{
-						<div class="col-md-12 text-center">
-							<SfButton CssClass="e-primary" OnClick="(() => ShowDFKQuests = !ShowDFKQuests)">
-								@if (ShowDFKQuests)
-								{
-									<span>
-										Show Serendale Quests
-									</span>
-								}
-								else
-								{
-									<span>
-										Show Crystalvale Quests
-									</span>
-								}
-							</SfButton>
-						</div>
-						<div class="col-12 text-center">
-							@foreach (Chain chain in Constants.ChainsList)
-							{
-								@if ((ShowDFKQuests && chain.Name == "DFK") || (ShowDFKQuests is false && chain.Name == "Klaytn"))
-								{
-									<div class="row">
-										<div class="col-12">
-											<h5>
-												@($"{chain.Name} Quest Contracts")
-											</h5>
-											@*First 8 quests are training quests*@
-											<div class="row">
-												@foreach (QuestContract quest in QuestContractDefinitions.DFKQuestContracts.First(qc => qc.Chain.Name == chain.Name).QuestContracts.Skip(8))
-												{
-													var questEnabled = Bots.Settings.ChainQuestEnabled.Find(qe => qe.Chain.Name == chain.Name).QuestEnabled.First(qe => qe.QuestId == quest.Id);
+                    <div class="col-md-6">
+                        <label for="MinStamina">
+                            Min Stamina to Quest
+                        </label>
+                        <SfNumericTextBox name="MinStamina"
+                                          TValue="int"
+                        @bind-Value="@Bots.Settings.MinStamina"
+                                          OnChange="@((val) => {Bots.SaveSettings();})" />
+                    </div>
 
-													<div class="col-md-4 col-lg-3">
-														<p>
-															@($"{quest.Name}")
-														</p>
-														<label class="d-inline-block">
-															Enabled
-															<SfCheckBox @bind-Checked=@questEnabled.Enabled />
-														</label>
-														<SfTooltip ID="tooltip"
-															IsSticky="false"
-															CloseDelay="500"
-															Target="#questEagerlyTooltip"
-															Content="@($"Quest Eagerly means the bot will quest your heroes when one hero reached maximum stamina. Cannot be enabled with Quest Instantly.")">
-															<label class="d-inline-block" id="questEagerlyTooltip">
-																Quest Eagerly
-																<SfCheckBox @bind-Checked=@questEnabled.QuestEagerly />
-															</label>
-														</SfTooltip>
-														<SfTooltip ID="tooltip"
-															IsSticky="false"
-															CloseDelay="500"
-															Target="#questInstantlyTooltip"
-															Content="@($"Quest Instantly means the bot will send your heroes asap when they're above minimum stamina. Cannot be enabled with Quest Eagerly.")">
-															<label class="d-inline-block" id="questInstantlyTooltip">
-															Quest Instantly
-															<SfCheckBox @bind-Checked=@questEnabled.QuestInstantly />
-														</label>
-														</SfTooltip>
-														<SfTooltip ID="tooltip"
-														   IsSticky="false"
-														   CloseDelay="500"
-														   Target="#capAttemptsTooltip"
-														   Content="@($"Cap attempts means that the bot will never maximize the # of attempts for the current stamina of a hero. It will use the attempts available with the set Minimum Stamina Amount.")">
-															<label class="d-inline-block" id="capAttemptsTooltip">
-																Cap attempts
-																<SfCheckBox @bind-Checked=@questEnabled.CapAttempts />
-															</label>
-														</SfTooltip>
-														<SfNumericTextBox name="@($"MinStam{chain.Name}{quest.Id}")"
-															TValue="int?"
-															Placeholder="@($"Min Stam: {Bots.Settings.MinStamina.ToString()}")"
-														@bind-Value="@questEnabled.MinStamina" />
-													</div>
-												}
-											</div>
-											<h5>
-												@($"{chain.Name} Training Quests")
-											</h5>
-											<div class="row">
-												@foreach (DFKStatAmount stat in Bots.Settings.MinTrainingStats)
-												{
-													var TQ = Bots.Settings.ChainQuestEnabled.Find(qe => qe.Chain.Name == chain.Name).QuestEnabled[Bots.Settings.MinTrainingStats.IndexOf(stat)];
-													<div class="col-md-6">
-														<p>
-															@($"{stat.Name} training.")
-														</p>
-														<label class="d-inline-block">
-															Enabled
-															<SfCheckBox @bind-Checked=@TQ.Enabled />
-														</label>
-														
-														<SfTooltip ID="tooltip"
-														   IsSticky="false"
-														   CloseDelay="500"
-														   Target="#questEagerlyTooltip"
-														   Content="@($"Quest Eagerly means the bot will quest your heroes when one hero reached maximum stamina. Cannot be enabled with Quest Instantly.")">
-															<label class="d-inline-block" id="questEagerlyTooltip">
-																Quest Eagerly
-																<SfCheckBox @bind-Checked=@TQ.QuestEagerly />
-															</label>
-														</SfTooltip>
+                    <div class="col-md-6">
+                        <label for="CancelTxnDelay">
+                            Cancel transaction delay. (Milliseconds)
+                        </label>
 
-														<SfTooltip ID="tooltip"
-														   IsSticky="false"
-														   CloseDelay="500"
-														   Target="#questInstantlyTooltip"
-														   Content="@($"Quest Instantly means the bot will send your heroes asap when they're above minimum stamina. Cannot be enabled with Quest Eagerly.")">
-															<label class="d-inline-block" id="questInstantlyTooltip">
-																Quest Instantly
-																<SfCheckBox @bind-Checked=@TQ.QuestInstantly />
-															</label>
-														</SfTooltip>
-														<SfTooltip ID="tooltip"
-															IsSticky="false"
-															CloseDelay="500"
-															Target="#capAttemptsTooltip"
-															Content="@($"Cap attempts means that the bot will never maximize the # of attempts for the current stamina of a hero. It will use the attempts available with the set Minimum Stamina Amount.")">
-															<label class="d-inline-block" id="capAttemptsTooltip">
-																Cap attempts
-																<SfCheckBox @bind-Checked=@TQ.CapAttempts />
-															</label>
-														</SfTooltip>
-														<SfNumericTextBox name="@($"MinStam{chain.Name}{Bots.Settings.MinTrainingStats.IndexOf(stat)}")"
-															TValue="int?"
-															@bind-Value="@TQ.MinStamina"
-															Placeholder="@($"Min Stam: {Bots.Settings.MinStamina.ToString()}")" />
-														<br>
-														<label for="@($"Training{stat.Id}")">
-															@($"Min Stat To Train")
-														</label>
-														<SfNumericTextBox Name="@($"Training{stat.Id}")" @bind-Value=@stat.Amount />
-													</div>
-												}
-											</div>
-										</div>
-									</div>
-								}
-							}
-						</div>
-					}
-					
-					<div>
-						<div class="text-center my-2" style="font-size:12px;">
-							<label for="LevelUp">
-								Enable Levelup
-								<SfCheckBox TChecked="bool" @bind-Checked=@Bots.Settings.LevelUp Name="LevelUp" />
-							</label>
-						</div>
-						@if(Bots.Settings.LevelUp)
-						{
-							<div class="row">
-								@foreach (LevelUpSetting levelSetting in Bots.Settings.LevelUpSettings)
-								{									
-									<h6 class="text-center">@(levelSetting.HeroClass) Levelup settings</h6>
-									<div class="col-md-4">
-										<SfCard CssClass="m-2">
-											<CardHeader>
-												Main (+1)
-											</CardHeader>
-											<CardContent>
-												<SfDropDownList TItem="DFKStat"
-													TValue="byte"
-													DataSource="@Constants.DFKStats"
-													@bind-value="levelSetting.MainAttribute.Id">
-													<DropDownListFieldSettings Value="Id" Text="Name"></DropDownListFieldSettings>
-												</SfDropDownList>
-											</CardContent>
-										</SfCard>
-									</div>
-									<div class="col-md-4">
-										<SfCard CssClass="m-2">
-											<CardHeader>
-												Secondary (50% +1)
-											</CardHeader>
-											<CardContent>
-												<SfDropDownList TItem="DFKStat"
-													TValue="byte"
-													DataSource="@Constants.DFKStats"
-														@bind-value="levelSetting.SecondaryAttribute.Id">
-													<DropDownListFieldSettings Value="Id" Text="Name"></DropDownListFieldSettings>
-												</SfDropDownList>
-											</CardContent>
-										</SfCard>
-									</div>
-									<div class="col-md-4">
-										<SfCard CssClass="m-2">
-											<CardHeader>
-												Secondary (50% +1)
-											</CardHeader>
-											<CardContent>
-												<SfDropDownList TItem="DFKStat"
-													TValue="byte"
-													DataSource="@Constants.DFKStats"
-													@bind-value="levelSetting.TertiaryAttribute.Id">
-													<DropDownListFieldSettings Value="Id" Text="Name"></DropDownListFieldSettings>
-												</SfDropDownList>
-											</CardContent>
-										</SfCard>
-									</div>
-								}
-							</div>
-						}
-					</div>
-				</div>
-			</EditForm>
-		</CardContent>
-	</SfCard>
+                        <SfNumericTextBox name="CancelTxnDelay"
+                                          TValue="int"
+                        @bind-Value="@Bots.Settings.CancelTxnDelay"
+                                          OnChange="@((val) => {Bots.SaveSettings();})" />
+                    </div>
+
+                    <div class="col-md-6 w100-tooltip">
+                        <label for="MaxGasFee">
+                            Max Gas Fee DFK
+                        </label>
+                        <SfNumericTextBox name="MaxGasFee"
+                                          TValue="decimal"
+                        @bind-Value="@Bots.Settings.MaxGasFeeGwei"
+                                          OnChange="@((val) => {Bots.SaveSettings();})" />
+                        <SfTooltip ID="tooltip"
+                                   IsSticky="false"
+                                   CloseDelay="500"
+                                   Target="#target"
+                                   Content="@($"Be careful about setting Priority fee too high, it will quickly drain your gas. Recommended range is between 0 and 1. If your transactions are failing increase priority fees a bit and restart the bot.")">
+                            <label for="MaxPriorityFee" id="target">
+                                Max Priority Fee DFK
+                            </label>
+                            <SfNumericTextBox name="MaxPriorityFee"
+                                              TValue="decimal"
+                            @bind-Value="@Bots.Settings.MaxPriorityFeeGwei"
+                                              OnChange="@((val) => {Bots.SaveSettings();})" />
+                        </SfTooltip>
+                    </div>
+                    <div class="col-md-6 w100-tooltip">
+                        <label for="MaxGasFeeKlaytn">
+                            Max Gas Fee Klaytn
+                        </label>
+                        <SfNumericTextBox name="MaxGasFeeKlaytn"
+                                          TValue="decimal"
+                        @bind-Value="@Bots.Settings.MaxGasFeeGweiKlaytn"
+                                          OnChange="@((val) => {Bots.SaveSettings();})" />
+                        <SfTooltip ID="tooltip"
+                                   IsSticky="false"
+                                   CloseDelay="500"
+                                   Target="#target"
+                                   Content="@($"Be careful about setting Priority fee too high, it will quickly drain your gas. Recommended range is between 0 and 1. If your transactions are failing increase priority fees a bit and restart the bot.")">
+                            <label for="MaxPriorityFeeKlaytn" id="target">
+                                Max Priority Fee Klaytn
+                            </label>
+                            <SfNumericTextBox name="MaxPriorityFeeKlaytn"
+                                              TValue="decimal"
+                                              Min="0"
+                                              Max="999"
+                            @bind-Value="@Bots.Settings.MaxPriorityFeeGweiKlaytn"
+                                              OnChange="@((val) => {Bots.SaveSettings();})" />
+                        </SfTooltip>
+                    </div>
+
+                    <div class="col-md-3 text-center mb-1">
+                        <label>
+                            Enable Hero Selling
+                            <SfCheckBox @bind-Checked=@Bots.Settings.SellHeroes />
+                        </label>
+                    </div>
+                    <div class="col-md-3 text-center mb-1">
+                        <label>
+                            Cancel Unpriced Hero Sales
+                            <SfCheckBox @bind-Checked=@Bots.Settings.CancelUnpricedHeroSales />
+                        </label>
+                    </div>
+                    <div class="col-md-3 text-center mb-1">
+                        <label>
+                            Enable Questing
+                            <SfCheckBox @bind-Checked=@Bots.Settings.QuestHeroes />
+                        </label>
+                    </div>
+                    <div class="col-md-3 text-center mb-1">
+                        <label>
+                            Use Stampots
+                            <SfCheckBox @bind-Checked=@Bots.Settings.UseStaminaPotions />
+                        </label>
+                    </div>
+                    <div class="col-md-3 text-center mb-1">
+                        <label>
+                            Force Stampots On Full XP
+                            <SfCheckBox @bind-Checked=@Bots.Settings.ForceStampotOnFullXP />
+                        </label>
+                    </div>
+                    <div class="col-md-3 text-center mb-1">
+                        <SfTooltip ID="tooltip"
+                                   IsSticky="false"
+                                   CloseDelay="500"
+                                   Target="#target"
+                                   Content="@($"When this option is enabled, heroes WITHOUT preferred quest assigned WILL NOT QUEST! Those heroes will stay idle and their stamina could be used by the player for PVE/PVP/etc.")">
+                            <label>
+                                Enable Not Questing Without Preferred Quest
+                                <SfCheckBox @bind-Checked=@Bots.Settings.EnableNotQuestingWithoutPreferredQuest />
+                            </label>
+                        </SfTooltip>
+                    </div>
+                    @if (Bots.Settings.QuestHeroes)
+                    {
+                        <div class="col-md-12 text-center">
+                            <SfButton CssClass="e-primary" OnClick="(() => ShowDFKQuests = !ShowDFKQuests)">
+                                @if (ShowDFKQuests)
+                                {
+                                    <span>
+                                        Show Serendale Quests
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span>
+                                        Show Crystalvale Quests
+                                    </span>
+                                }
+                            </SfButton>
+                        </div>
+                        <div class="col-12 text-center">
+                            @foreach (Chain chain in Constants.ChainsList)
+                            {
+                                @if ((ShowDFKQuests && chain.Name == "DFK") || (ShowDFKQuests is false && chain.Name == "Klaytn"))
+                                {
+                                    <div class="row">
+                                        <div class="col-12">
+                                            <h5>
+                                                @($"{chain.Name} Quest Contracts")
+                                            </h5>
+                                            @*First 8 quests are training quests*@
+                                            <div class="row">
+                                                @foreach (QuestContract quest in QuestContractDefinitions.DFKQuestContracts.First(qc => qc.Chain.Name == chain.Name).QuestContracts.Skip(8))
+                                                {
+                                                    var questEnabled = Bots.Settings.ChainQuestEnabled.Find(qe => qe.Chain.Name == chain.Name).QuestEnabled.First(qe => qe.QuestId == quest.Id);
+
+                                                    <div class="col-md-4 col-lg-3">
+                                                        <p>
+                                                            @($"{quest.Name}")
+                                                        </p>
+                                                        <label class="d-inline-block">
+                                                            Enabled
+                                                            <SfCheckBox @bind-Checked=@questEnabled.Enabled />
+                                                        </label>
+                                                        <SfTooltip ID="tooltip"
+                                                                   IsSticky="false"
+                                                                   CloseDelay="500"
+                                                                   Target="#questEagerlyTooltip"
+                                                                   Content="@($"Quest Eagerly means the bot will quest your heroes when one hero reached maximum stamina. Cannot be enabled with Quest Instantly.")">
+                                                            <label class="d-inline-block" id="questEagerlyTooltip">
+                                                                Quest Eagerly
+                                                                <SfCheckBox @bind-Checked=@questEnabled.QuestEagerly />
+                                                            </label>
+                                                        </SfTooltip>
+                                                        <SfTooltip ID="tooltip"
+                                                                   IsSticky="false"
+                                                                   CloseDelay="500"
+                                                                   Target="#questInstantlyTooltip"
+                                                                   Content="@($"Quest Instantly means the bot will send your heroes asap when they're above minimum stamina. Cannot be enabled with Quest Eagerly.")">
+                                                            <label class="d-inline-block" id="questInstantlyTooltip">
+                                                                Quest Instantly
+                                                                <SfCheckBox @bind-Checked=@questEnabled.QuestInstantly />
+                                                            </label>
+                                                        </SfTooltip>
+                                                        <SfTooltip ID="tooltip"
+                                                                   IsSticky="false"
+                                                                   CloseDelay="500"
+                                                                   Target="#capAttemptsTooltip"
+                                                                   Content="@($"Cap attempts means that the bot will never maximize the # of attempts for the current stamina of a hero. It will use the attempts available with the set Minimum Stamina Amount.")">
+                                                            <label class="d-inline-block" id="capAttemptsTooltip">
+                                                                Cap attempts
+                                                                <SfCheckBox @bind-Checked=@questEnabled.CapAttempts />
+                                                            </label>
+                                                        </SfTooltip>
+                                                        <SfNumericTextBox name="@($"MinStam{chain.Name}{quest.Id}")"
+                                                                          TValue="int?"
+                                                                          Placeholder="@($"Min Stam: {Bots.Settings.MinStamina.ToString()}")"
+                                                        @bind-Value="@questEnabled.MinStamina" />
+                                                    </div>
+                                                }
+                                            </div>
+                                            <h5>
+                                                @($"{chain.Name} Training Quests")
+                                            </h5>
+                                            <div class="row">
+                                                @foreach (DFKStatAmount stat in Bots.Settings.MinTrainingStats)
+                                                {
+                                                    var TQ = Bots.Settings.ChainQuestEnabled.Find(qe => qe.Chain.Name == chain.Name).QuestEnabled[Bots.Settings.MinTrainingStats.IndexOf(stat)];
+                                                    <div class="col-md-6">
+                                                        <p>
+                                                            @($"{stat.Name} training.")
+                                                        </p>
+                                                        <label class="d-inline-block">
+                                                            Enabled
+                                                            <SfCheckBox @bind-Checked=@TQ.Enabled />
+                                                        </label>
+
+                                                        <SfTooltip ID="tooltip"
+                                                                   IsSticky="false"
+                                                                   CloseDelay="500"
+                                                                   Target="#questEagerlyTooltip"
+                                                                   Content="@($"Quest Eagerly means the bot will quest your heroes when one hero reached maximum stamina. Cannot be enabled with Quest Instantly.")">
+                                                            <label class="d-inline-block" id="questEagerlyTooltip">
+                                                                Quest Eagerly
+                                                                <SfCheckBox @bind-Checked=@TQ.QuestEagerly />
+                                                            </label>
+                                                        </SfTooltip>
+
+                                                        <SfTooltip ID="tooltip"
+                                                                   IsSticky="false"
+                                                                   CloseDelay="500"
+                                                                   Target="#questInstantlyTooltip"
+                                                                   Content="@($"Quest Instantly means the bot will send your heroes asap when they're above minimum stamina. Cannot be enabled with Quest Eagerly.")">
+                                                            <label class="d-inline-block" id="questInstantlyTooltip">
+                                                                Quest Instantly
+                                                                <SfCheckBox @bind-Checked=@TQ.QuestInstantly />
+                                                            </label>
+                                                        </SfTooltip>
+                                                        <SfTooltip ID="tooltip"
+                                                                   IsSticky="false"
+                                                                   CloseDelay="500"
+                                                                   Target="#capAttemptsTooltip"
+                                                                   Content="@($"Cap attempts means that the bot will never maximize the # of attempts for the current stamina of a hero. It will use the attempts available with the set Minimum Stamina Amount.")">
+                                                            <label class="d-inline-block" id="capAttemptsTooltip">
+                                                                Cap attempts
+                                                                <SfCheckBox @bind-Checked=@TQ.CapAttempts />
+                                                            </label>
+                                                        </SfTooltip>
+                                                        <SfNumericTextBox name="@($"MinStam{chain.Name}{Bots.Settings.MinTrainingStats.IndexOf(stat)}")"
+                                                                          TValue="int?"
+                                                        @bind-Value="@TQ.MinStamina"
+                                                                          Placeholder="@($"Min Stam: {Bots.Settings.MinStamina.ToString()}")" />
+                                                        <br>
+                                                        <label for="@($"Training{stat.Id}")">
+                                                            @($"Min Stat To Train")
+                                                        </label>
+                                                        <SfNumericTextBox Name="@($"Training{stat.Id}")" @bind-Value=@stat.Amount />
+                                                    </div>
+                                                }
+                                            </div>
+                                        </div>
+                                    </div>
+                                }
+                            }
+                        </div>
+                    }
+
+                    <div>
+                        <div class="text-center my-2" style="font-size:12px;">
+                            <label for="LevelUp">
+                                Enable Levelup
+                                <SfCheckBox TChecked="bool" @bind-Checked=@Bots.Settings.LevelUp Name="LevelUp" />
+                            </label>
+                        </div>
+                        @if (Bots.Settings.LevelUp)
+                        {
+                            <div class="row">
+                                @foreach (LevelUpSetting levelSetting in Bots.Settings.LevelUpSettings)
+                                {
+                                    <h6 class="text-center">@(levelSetting.HeroClass) Levelup settings</h6>
+                                    <div class="col-md-4">
+                                        <SfCard CssClass="m-2">
+                                            <CardHeader>
+                                                Main (+1)
+                                            </CardHeader>
+                                            <CardContent>
+                                                <SfDropDownList TItem="DFKStat"
+                                                                TValue="byte"
+                                                                DataSource="@Constants.DFKStats"
+                                                @bind-value="levelSetting.MainAttribute.Id">
+                                                    <DropDownListFieldSettings Value="Id" Text="Name"></DropDownListFieldSettings>
+                                                </SfDropDownList>
+                                            </CardContent>
+                                        </SfCard>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <SfCard CssClass="m-2">
+                                            <CardHeader>
+                                                Secondary (50% +1)
+                                            </CardHeader>
+                                            <CardContent>
+                                                <SfDropDownList TItem="DFKStat"
+                                                                TValue="byte"
+                                                                DataSource="@Constants.DFKStats"
+                                                @bind-value="levelSetting.SecondaryAttribute.Id">
+                                                    <DropDownListFieldSettings Value="Id" Text="Name"></DropDownListFieldSettings>
+                                                </SfDropDownList>
+                                            </CardContent>
+                                        </SfCard>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <SfCard CssClass="m-2">
+                                            <CardHeader>
+                                                Secondary (50% +1)
+                                            </CardHeader>
+                                            <CardContent>
+                                                <SfDropDownList TItem="DFKStat"
+                                                                TValue="byte"
+                                                                DataSource="@Constants.DFKStats"
+                                                @bind-value="levelSetting.TertiaryAttribute.Id">
+                                                    <DropDownListFieldSettings Value="Id" Text="Name"></DropDownListFieldSettings>
+                                                </SfDropDownList>
+                                            </CardContent>
+                                        </SfCard>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    </div>
+                </div>
+            </EditForm>
+        </CardContent>
+    </SfCard>
 </div>


### PR DESCRIPTION
- Added a property to Enable this feature in `DFKBotSettings`. This is the only change there except the formatting that VS did:
`public bool EnableNotQuestingWithoutPreferredQuest { get; set; } = false;`
- The setting is used in `DFKBot` method `GetMinStaminaBotHero` to return 999 min stamina if there is no preferred quest assigned to the hero and `EnableNotQuestingWithoutPreferredQuest` is false or `SuggestedQuest` is null.